### PR TITLE
fix: serve service worker on vercel

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,6 @@
 {
-  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+  "routes": [
+    { "handle": "filesystem" },
+    { "src": "/.*", "dest": "/index.html" }
+  ]
 }


### PR DESCRIPTION
## Summary
- serve `mockServiceWorker.js` correctly on Vercel by honoring existing files before SPA fallback

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68beaf0bad388320a00e429c83593db8