### PR TITLE
Implement global search and course tabs with tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "react-dom": "^18.2.0",
         "react-markdown": "^8.0.7",
         "react-redux": "^8.1.1",
-        "react-router-dom": "^6.16.0"
+        "react-router-dom": "^6.16.0",
+        "web-vitals": "^3.3.0"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.0.0",
@@ -8683,6 +8684,12 @@
       "optionalDependencies": {
         "@zxing/text-encoding": "0.9.0"
       }
+    },
+    "node_modules/web-vitals": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-3.3.0.tgz",
+      "integrity": "sha512-GZsEmJBNclIpViS/7QVOTr7Kbt4BgLeR7kQ5zCCtJVuiWsA+K6xTXaoEXssvl8yYFICEyNmA2Nr+vgBYTnS4bA==",
+      "license": "Apache-2.0"
     },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "react-dom": "^18.2.0",
     "react-markdown": "^8.0.7",
     "react-redux": "^8.1.1",
-    "react-router-dom": "^6.16.0"
+    "react-router-dom": "^6.16.0",
+    "web-vitals": "^3.3.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.0.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ const CodingTest = lazy(() => import('./pages/CodingTest'));
 const Portal = lazy(() => import('./pages/Portal'));
 const Staff = lazy(() => import('./pages/Staff'));
 const NotFound = lazy(() => import('./pages/NotFound'));
+const SearchResults = lazy(() => import('./pages/SearchResults'));
 
 const App = () => (
   <Layout>
@@ -29,6 +30,7 @@ const App = () => (
         <Route path="/news" element={<NewsList />} />
         <Route path="/news/:slug" element={<NewsDetail />} />
         <Route path="/people" element={<People />} />
+        <Route path="/search" element={<SearchResults />} />
         <Route path="/admissions" element={<Admissions />} />
         <Route path="/contact" element={<Contact />} />
         <Route path="/coding-test" element={<CodingTest />} />

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -1,9 +1,20 @@
-import { useState } from 'react';
-import { NavLink } from 'react-router-dom';
+import { useState, FormEvent } from 'react';
+import { NavLink, useNavigate } from 'react-router-dom';
+import { useDispatch } from 'react-redux';
+import { setQuery } from '../../store/searchSlice';
 import './Header.css';
 
 const Header = () => {
   const [menuOpen, setMenuOpen] = useState(false);
+  const [query, setLocalQuery] = useState('');
+  const dispatch = useDispatch();
+  const navigate = useNavigate();
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    dispatch(setQuery(query));
+    navigate(`/search?q=${encodeURIComponent(query)}`);
+  };
   return (
     <header className="header">
       <div className="top">
@@ -19,14 +30,19 @@ const Header = () => {
         >
           Menu
         </button>
-        <div className="search">
+        <form className="search" role="search" onSubmit={handleSubmit}>
+          <label className="visually-hidden" htmlFor="global-search">
+            Search
+          </label>
           <input
+            id="global-search"
             type="search"
             placeholder="Search"
             aria-label="Search"
-            disabled
+            value={query}
+            onChange={e => setLocalQuery(e.target.value)}
           />
-        </div>
+        </form>
       </div>
       <nav
         id="primary-nav"

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,7 @@ import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 import { store } from './store';
 import './styles/tokens.css';
+import { logWebVitals } from './utils/webVitals';
 
 if (import.meta.env.DEV) {
   const { worker } = await import('./mocks/browser');
@@ -22,5 +23,7 @@ ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
         <App />
       </BrowserRouter>
     </Provider>
-  </React.StrictMode>
+  </React.StrictMode>,
 );
+
+logWebVitals();

--- a/src/pages/Courses/CourseDetail.tsx
+++ b/src/pages/Courses/CourseDetail.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, useSearchParams } from 'react-router-dom';
 import PageHeader from '../../components/PageHeader';
 import Button from '../../components/ui/Button';
 
@@ -12,6 +12,10 @@ interface Course {
 const CourseDetail = () => {
   const { code } = useParams();
   const [course, setCourse] = useState<Course | null>(null);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const tab = searchParams.get('tab') || 'overview';
+
+  const setTab = (t: string) => setSearchParams({ tab: t });
 
   useEffect(() => {
     fetch(`${window.location.origin}/api/courses`)
@@ -30,12 +34,37 @@ const CourseDetail = () => {
         <p>UCAS code: {course.code}</p>
       </PageHeader>
       <div>
-        <nav aria-label="Course">
-          <button>Overview</button>
-          <button>Modules</button>
-          <button>Entry requirements</button>
+        <nav aria-label="Course" role="tablist">
+          <button
+            role="tab"
+            aria-selected={tab === 'overview'}
+            onClick={() => setTab('overview')}
+            id="overview-tab"
+          >
+            Overview
+          </button>
+          <button
+            role="tab"
+            aria-selected={tab === 'modules'}
+            onClick={() => setTab('modules')}
+            id="modules-tab"
+          >
+            Modules
+          </button>
+          <button
+            role="tab"
+            aria-selected={tab === 'entry'}
+            onClick={() => setTab('entry')}
+            id="entry-tab"
+          >
+            Entry requirements
+          </button>
         </nav>
-        <p>{course.overview || 'TODO: Overview content'}</p>
+        {tab === 'overview' && (
+          <p>{course.overview || 'Overview coming soon.'}</p>
+        )}
+        {tab === 'modules' && <p>Module information coming soon.</p>}
+        {tab === 'entry' && <p>Entry requirements coming soon.</p>}
         <section aria-labelledby="apply">
           <h2 id="apply">Apply now</h2>
           <Button disabled>Apply now</Button>

--- a/src/pages/News/NewsDetail.tsx
+++ b/src/pages/News/NewsDetail.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, Link } from 'react-router-dom';
 import PageHeader from '../../components/PageHeader';
 
 interface NewsItem {
@@ -12,11 +12,17 @@ interface NewsItem {
 const NewsDetail = () => {
   const { slug } = useParams();
   const [item, setItem] = useState<NewsItem | null>(null);
+  const [related, setRelated] = useState<NewsItem[]>([]);
 
   useEffect(() => {
     fetch(`/api/news/${slug}`)
       .then(res => res.json())
       .then(setItem);
+    fetch('/api/news')
+      .then(res => res.json())
+      .then((items: NewsItem[]) => {
+        setRelated(items.filter(n => n.slug !== slug).slice(0, 3));
+      });
   }, [slug]);
 
   if (!item) return <p>Loading…</p>;
@@ -27,10 +33,18 @@ const NewsDetail = () => {
         <p>{new Date(item.date).toLocaleDateString('en-GB', { dateStyle: 'long' })}</p>
       </PageHeader>
       <p>{item.body}</p>
-      <section>
-        <h2>Related articles</h2>
-        <div>TODO</div>
-      </section>
+      {related.length > 0 && (
+        <section aria-labelledby="related-heading">
+          <h2 id="related-heading">Related articles</h2>
+          <ul>
+            {related.map(r => (
+              <li key={r.slug}>
+                <Link to={`/news/${r.slug}`}>{r.title}</Link>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
     </>
   );
 };

--- a/src/pages/SearchResults.tsx
+++ b/src/pages/SearchResults.tsx
@@ -1,0 +1,87 @@
+import { useEffect, useState } from 'react';
+import { useSearchParams, Link } from 'react-router-dom';
+import PageHeader from '../components/PageHeader';
+
+interface Course { code: string; title: string; }
+interface NewsItem { slug: string; title: string; }
+interface Person { id: number; name: string; }
+
+const SearchResults = () => {
+  const [searchParams] = useSearchParams();
+  const query = searchParams.get('q')?.toLowerCase() || '';
+  const [courses, setCourses] = useState<Course[]>([]);
+  const [news, setNews] = useState<NewsItem[]>([]);
+  const [people, setPeople] = useState<Person[]>([]);
+
+  useEffect(() => {
+    if (!query) return;
+    Promise.all([
+      fetch(`${window.location.origin}/api/courses`).then(r => r.json()),
+      fetch(`${window.location.origin}/api/news`).then(r => r.json()),
+      fetch(`${window.location.origin}/api/people`).then(r => r.json()),
+    ]).then(([c, n, p]) => {
+      setCourses(c.filter((x: Course) => x.title.toLowerCase().includes(query)));
+      setNews(n.filter((x: NewsItem) => x.title.toLowerCase().includes(query)));
+      setPeople(p.filter((x: Person) => x.name.toLowerCase().includes(query)));
+    });
+  }, [query]);
+
+  if (!query) {
+    return (
+      <>
+        <PageHeader title="Search" />
+        <p>Please enter a search term.</p>
+      </>
+    );
+  }
+
+  const hasResults = courses.length || news.length || people.length;
+
+  return (
+    <>
+      <PageHeader title={`Search results for "${searchParams.get('q') || ''}"`} />
+      {hasResults ? (
+        <>
+          {!!courses.length && (
+            <section aria-labelledby="courses-heading">
+              <h2 id="courses-heading">Courses</h2>
+              <ul>
+                {courses.map(c => (
+                  <li key={c.code}>
+                    <Link to={`/courses/${c.code}`}>{c.title}</Link>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          )}
+          {!!news.length && (
+            <section aria-labelledby="news-heading">
+              <h2 id="news-heading">News</h2>
+              <ul>
+                {news.map(n => (
+                  <li key={n.slug}>
+                    <Link to={`/news/${n.slug}`}>{n.title}</Link>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          )}
+          {!!people.length && (
+            <section aria-labelledby="people-heading">
+              <h2 id="people-heading">People</h2>
+              <ul>
+                {people.map(p => (
+                  <li key={p.id}>{p.name}</li>
+                ))}
+              </ul>
+            </section>
+          )}
+        </>
+      ) : (
+        <p>No results found.</p>
+      )}
+    </>
+  );
+};
+
+export default SearchResults;

--- a/src/pages/__tests__/NewsList.test.tsx
+++ b/src/pages/__tests__/NewsList.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+import { beforeAll, afterEach, afterAll, test, expect } from 'vitest';
+import NewsList from '../News/NewsList';
+import { news } from '../../data/news';
+
+const server = setupServer(
+  rest.get('/api/news', (_req, res, ctx) => res(ctx.json(news)))
+);
+
+beforeAll(() => server.listen());
+afterEach(() => {
+  server.resetHandlers();
+  cleanup();
+});
+afterAll(() => server.close());
+
+test('paginates news items', async () => {
+  render(
+    <MemoryRouter>
+      <NewsList />
+    </MemoryRouter>
+  );
+  // initial page shows first two items
+  expect(await screen.findByText(/New library opening/i)).toBeInTheDocument();
+  expect(screen.getByText(/Research grant awarded/i)).toBeInTheDocument();
+  // move to next page
+  fireEvent.click(screen.getByText(/Next/i));
+  expect(await screen.findByText(/Graduation ceremony/i)).toBeInTheDocument();
+});

--- a/src/pages/__tests__/Search.test.tsx
+++ b/src/pages/__tests__/Search.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen, cleanup } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { Provider } from 'react-redux';
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+import { beforeAll, afterEach, afterAll, test, expect } from 'vitest';
+import SearchResults from '../SearchResults';
+import { store } from '../../store';
+import { courses } from '../../data/courses';
+import { news } from '../../data/news';
+import { people } from '../../data/people';
+
+const server = setupServer(
+  rest.get('/api/courses', (_req, res, ctx) => res(ctx.json(courses))),
+  rest.get('/api/news', (_req, res, ctx) => res(ctx.json(news))),
+  rest.get('/api/people', (_req, res, ctx) => res(ctx.json(people)))
+);
+
+beforeAll(() => server.listen());
+afterEach(() => {
+  server.resetHandlers();
+  cleanup();
+});
+afterAll(() => server.close());
+
+test('shows search results', async () => {
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={["/search?q=computer"]}>
+        <SearchResults />
+      </MemoryRouter>
+    </Provider>
+  );
+  expect(await screen.findByText(/Computer Science BSc/i)).toBeInTheDocument();
+});
+
+test('shows no results message', async () => {
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={["/search?q=unknown"]}>
+        <SearchResults />
+      </MemoryRouter>
+    </Provider>
+  );
+  expect(await screen.findByText(/No results found/i)).toBeInTheDocument();
+});

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -67,3 +67,15 @@ input, select, textarea {
   font-family: inherit;
   font-size: 1rem;
 }
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/src/utils/webVitals.ts
+++ b/src/utils/webVitals.ts
@@ -1,0 +1,7 @@
+import { onCLS, onFID, onLCP } from 'web-vitals';
+
+export const logWebVitals = () => {
+  onCLS(console.log);
+  onFID(console.log);
+  onLCP(console.log);
+};


### PR DESCRIPTION
## Summary
- Enable global search with a new results page filtering courses, news, and people
- Add tabbed Course Detail view stored in the URL and related news section
- Log Web Vitals and support accessibility with visually hidden labels
- Include unit tests for search behaviour and news pagination

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bec5f9748c83208bebd708e3c52d9e